### PR TITLE
Fix the footer on small screens.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1,3 +1,8 @@
+body
+{
+	margin-bottom: 10rem;
+}
+
 .top-bar, .top-bar-left, .top-bar-right li{
 background-color:#fff !important;
 }
@@ -10,7 +15,6 @@ padding: 0 !important;
 height:80px;
 }
 
-
 .top-bar-right{
 padding: 20px;
 }
@@ -21,4 +25,9 @@ padding: 20px;
 
 .callout{
 	background-color: #eee;
+}
+
+.footer
+{
+	background: white;
 }


### PR DESCRIPTION
On small screens the footer appeared over the top of the text at the bottom of the page. This commit adds a background colour to the footer to make sure that you can read it, and also adds a bit of a margin to the bottom of the body so that the content at the very bottom of the page can be seen.
